### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -18,7 +18,7 @@ MAX_REDIRECTS = 5  # Limit redirects to prevent DoS attacks
 
 def _strip_tags(text: str) -> str:
     """Remove HTML tags and decode entities."""
-    text = re.sub(r"<script[\s\S]*?</script>", "", text, flags=re.I)
+    text = re.sub(r"(?is)<script\b[\s\S]*?</script\b[^>]*>", "", text)
     text = re.sub(r"<style[\s\S]*?</style>", "", text, flags=re.I)
     text = re.sub(r"<[^>]+>", "", text)
     return html.unescape(text).strip()


### PR DESCRIPTION
Potential fix for [https://github.com/Skye-flyhigh/black-cat-py/security/code-scanning/1](https://github.com/Skye-flyhigh/black-cat-py/security/code-scanning/1)

In general, the problem is that the regular expression for script blocks is too strict about the exact closing tag syntax. It only matches `</script>` with no internal whitespace or attributes before `>`, while browsers accept forms like `</script >` or even `</script foo="bar">`. The fix is to update the closing-tag part of the regex so it tolerates optional whitespace and arbitrary attributes after the `script` name and before the closing `>`.

The best targeted fix, without changing existing behavior beyond making script removal more robust, is to adjust line 21’s regex from `"<script[\s\S]*?</script>"` to something like `r"(?is)<script\b[\s\S]*?</script\b[^>]*>"`. This does a few things: (1) uses inline flags `(?is)` for case-insensitive and dot-matches-newline, removing the need for a separate `flags` argument; (2) ensures we match the `script` tag name as a complete word with `\b`; and (3) allows arbitrary attributes and whitespace after `/script` before the closing `>`, via `</script\b[^>]*>`. No other functionality needs to change: the function still strips script, then style tags, then any remaining tags and decodes entities. Only line 21 in `nanobot/agent/tools/web.py` needs to be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
